### PR TITLE
fix(008): resolve build warnings and runtime errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ AcroYoga Community connects practitioners with local events, teachers, and each 
 - **Permissions & Creator Accounts** — Hierarchical role-based access scoped to geographic regions (city → country → global)
 - **Teacher Profiles & Reviews** — Verified instructor profiles, certification tracking, ratings and reviews
 - **Payments & Bookings** — Stripe Connect for creator payouts, concession pricing, credits, and refund policies
+- **Cross-Platform UI** — Shared design token pipeline (CSS, TS, Swift, Kotlin) with 15 reusable components and Storybook 10 component explorer
 
 ## Tech Stack
 
 | Layer | Technology |
 |-------|-----------|
-| Framework | [Next.js 16](https://nextjs.org) (App Router, React 19, Server Components) |
+| Framework | [Next.js 16](https://nextjs.org) (App Router, React 19, Server Components, `proxy.ts`) |
 | Language | TypeScript 5.9 (strict mode) |
 | Styling | Tailwind CSS 4 |
 | Database | PostgreSQL ([node-pg](https://node-postgres.com/)) with raw SQL migrations |
@@ -25,6 +26,7 @@ AcroYoga Community connects practitioners with local events, teachers, and each 
 | Payments | [Stripe](https://stripe.com) + Stripe Connect |
 | Validation | [Zod 4](https://zod.dev) at every API boundary |
 | Testing | [Vitest 4](https://vitest.dev) + [PGlite](https://electric-sql.com/product/pglite) (in-memory Postgres) |
+| Components | [Storybook 10](https://storybook.js.org) with `@storybook/react-vite` |
 | Storage | Azure Blob Storage (media uploads with EXIF stripping) |
 | Recurrence | [rrule](https://github.com/jkbrzt/rrule) for iCal-compliant scheduling |
 

--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -1,4 +1,8 @@
 import type { StorybookConfig } from "storybook/internal/types";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const config: StorybookConfig = {
   stories: [
@@ -10,6 +14,19 @@ const config: StorybookConfig = {
     "@storybook/addon-a11y",
     "@storybook/addon-themes",
   ],
+  viteFinal(config) {
+    const packagesDir = path.resolve(__dirname, "../../../packages");
+    config.resolve ??= {};
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@acroyoga/shared": path.join(packagesDir, "shared/src"),
+      "@acroyoga/shared-ui": path.join(packagesDir, "shared-ui/src"),
+      "@acroyoga/tokens": path.join(packagesDir, "tokens/src"),
+    };
+    config.build ??= {};
+    config.build.chunkSizeWarningLimit = 1200;
+    return config;
+  },
 };
 
 export default config;

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useSession } from "next-auth/react";
 import Link from "next/link";
 
 interface SocialLinkForm {
@@ -11,7 +10,6 @@ interface SocialLinkForm {
 }
 
 export default function ProfilePage() {
-  const { status: authStatus } = useSession();
   const [displayName, setDisplayName] = useState("");
   const [bio, setBio] = useState("");
   const [defaultRole, setDefaultRole] = useState<string>("hybrid");
@@ -20,6 +18,7 @@ export default function ProfilePage() {
   const [homeCityName, setHomeCityName] = useState<string | null>(null);
   const [socialLinks, setSocialLinks] = useState<SocialLinkForm[]>([]);
   const [loading, setLoading] = useState(true);
+  const [unauthenticated, setUnauthenticated] = useState(false);
   const [saving, setSaving] = useState(false);
   const [detecting, setDetecting] = useState(false);
   const [saveStatus, setSaveStatus] = useState<"idle" | "success" | "error">("idle");
@@ -27,8 +26,16 @@ export default function ProfilePage() {
 
   useEffect(() => {
     fetch("/api/profiles/me")
-      .then((r) => r.json())
+      .then((r) => {
+        if (r.status === 401) {
+          setUnauthenticated(true);
+          setLoading(false);
+          return null;
+        }
+        return r.json();
+      })
       .then((data) => {
+        if (!data) return;
         setDisplayName(data.displayName ?? "");
         setBio(data.bio ?? "");
         setDefaultRole(data.defaultRole ?? "hybrid");
@@ -42,6 +49,10 @@ export default function ProfilePage() {
             visibility: l.visibility,
           })) ?? [],
         );
+        setLoading(false);
+      })
+      .catch(() => {
+        setUnauthenticated(true);
         setLoading(false);
       });
   }, []);
@@ -112,7 +123,7 @@ export default function ProfilePage() {
     setSocialLinks(socialLinks.filter((_, i) => i !== index));
   }
 
-  if (authStatus === "unauthenticated") {
+  if (unauthenticated) {
     return (
       <div className="max-w-2xl mx-auto px-4 py-12 text-center">
         <p className="text-gray-600 text-lg">Please sign in to view your profile.</p>

--- a/apps/web/src/app/teachers/page.tsx
+++ b/apps/web/src/app/teachers/page.tsx
@@ -17,6 +17,7 @@ interface TeacherSummary {
 export default function TeachersPage() {
   const [teachers, setTeachers] = useState<TeacherSummary[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [specialty, setSpecialty] = useState("");
   const [badge, setBadge] = useState("");
@@ -27,10 +28,19 @@ export default function TeachersPage() {
     if (specialty) params.set("specialty", specialty);
     if (badge) params.set("badge", badge);
 
+    setLoading(true);
+    setError(null);
     fetch(`/api/teachers?${params.toString()}`)
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) throw new Error("Failed to load teachers");
+        return r.json();
+      })
       .then((data) => {
         setTeachers(data.teachers ?? []);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : "Unknown error");
         setLoading(false);
       });
   }, [query, specialty, badge]);
@@ -66,7 +76,12 @@ export default function TeachersPage() {
         />
       </div>
 
-      {loading ? (
+      {error ? (
+        <div className="text-center py-12">
+          <p className="text-red-600 text-lg">{error}</p>
+          <button onClick={() => window.location.reload()} className="text-indigo-600 hover:underline mt-2">Retry</button>
+        </div>
+      ) : loading ? (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {[...Array(6)].map((_, i) => (
             <div key={i} className="animate-pulse border rounded-lg p-4">

--- a/apps/web/src/lib/auth/session.ts
+++ b/apps/web/src/lib/auth/session.ts
@@ -30,14 +30,12 @@ export async function getServerSession(): Promise<Session | null> {
   return { userId: session.user.id };
 }
 
-function getMockSession(): Session | null {
+async function getMockSession(): Promise<Session | null> {
   // Try cookie first (dev server with browser)
   let userId: string | null = null;
   try {
-    // Dynamic import to avoid build errors in test environments
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { cookies } = require("next/headers");
-    const cookieStore = cookies();
+    const { cookies } = await import("next/headers");
+    const cookieStore = await cookies();
     const mockCookie = cookieStore.get("mock-user-id");
     if (mockCookie?.value) {
       userId = mockCookie.value;

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { handleMockUserParam } from "@/lib/auth/mock-middleware";
 
-export function middleware(req: NextRequest): NextResponse | undefined {
+export function proxy(req: NextRequest): NextResponse | undefined {
   // Mock auth query parameter handling (dev only — no-op in production)
   const mockResponse = handleMockUserParam(req);
   if (mockResponse) return mockResponse;

--- a/specs/008-cross-platform-ui/bugfix-plan.md
+++ b/specs/008-cross-platform-ui/bugfix-plan.md
@@ -1,0 +1,54 @@
+# Bugfix Plan: Post-Build Error Remediation (Spec 008)
+
+**Branch**: `008-cross-platform-ui` | **Date**: 2026-03-18
+**Input**: Build warnings, Storybook warnings, and runtime errors observed after Phase 4 completion
+
+## Summary
+
+Fix five categories of issues discovered during build and runtime testing:
+
+1. **Next.js 16 middleware deprecation** — Rename `middleware.ts` to `proxy.ts` per Next.js 16.1 convention
+2. **Storybook workspace package resolution** — Configure Vite aliases so Storybook resolves `@acroyoga/*` workspace packages
+3. **Profile page mock-auth incompatibility** — Profile page uses NextAuth `useSession()` which returns "unauthenticated" in mock-auth mode, blocking the profile form
+4. **cookies() async breaking change** — `cookies()` from `next/headers` is async in Next.js 16; `getMockSession()` calls it synchronously, breaking cookie-based mock user switching
+5. **Teachers page error handling** — No `.catch()` on the fetch chain; API errors leave the page stuck in loading state
+
+## Fixes
+
+### F1: Middleware → Proxy Migration
+
+- Rename `apps/web/src/middleware.ts` → `apps/web/src/proxy.ts`
+- Rename exported function `middleware` → `proxy`
+- Keep `config` export unchanged
+- Reference: https://nextjs.org/docs/messages/middleware-to-proxy
+
+### F2: Storybook Workspace Package Resolution
+
+- Add `viteFinal` to `apps/web/.storybook/main.ts`
+- Configure `resolve.alias` for `@acroyoga/shared`, `@acroyoga/shared-ui`, `@acroyoga/tokens`
+- Set `build.chunkSizeWarningLimit` to suppress the large-chunk warning (Storybook internal chunks)
+
+### F3: Profile Page Mock-Auth Fix
+
+- Remove `useSession()` from `next-auth/react` in `apps/web/src/app/profile/page.tsx`
+- Determine auth status from the `/api/profiles/me` response (401 = unauthenticated, 200 = authenticated)
+- Consistent with how events and teachers pages work (fetch-based, no client-side session check)
+
+### F4: cookies() Async Fix
+
+- Make `getMockSession()` async in `apps/web/src/lib/auth/session.ts`
+- Dynamically import `cookies` from `next/headers` with `await`
+- Preserves the same fallback chain: cookie → module state → default user
+
+### F5: Teachers Page Error Handling
+
+- Add `.catch()` to the fetch chain in `apps/web/src/app/teachers/page.tsx`
+- Show error state consistent with EventsListPage pattern
+
+## Verification
+
+- `npm run build` — zero warnings (no middleware deprecation)
+- `npx storybook build` — no "unable to find package.json" warnings
+- `npm test` — 339/339 tests pass (no regressions)
+- Profile page loads in mock-auth mode without sign-in prompt
+- Events and Teachers pages show proper error states on API failure


### PR DESCRIPTION
## Summary

Fixes five build/runtime issues discovered after Spec 008 Phase 4 completion.

### Changes

- **F1** `proxy.ts`: Rename `middleware.ts` → `proxy.ts` (Next.js 16 convention)
- **F2** `.storybook/main.ts`: Add `viteFinal` with Vite aliases for `@acroyoga/*` workspace packages
- **F3** `profile/page.tsx`: Remove `useSession()` from next-auth; use API-based auth detection
- **F4** `session.ts`: Make `cookies()` async via dynamic import (Next.js 16 breaking change)
- **F5** `teachers/page.tsx`: Add error state, `.catch()` handler, and retry button

### README Updates

- Added Cross-Platform UI to capabilities list
- Added Storybook 10 to tech stack table
- Noted `proxy.ts` convention in framework row

### Verification

- `npm run build` — zero warnings, zero errors
- `npm test` — 339/339 pass
- Storybook build succeeds
- `tsc --noEmit` — zero type errors

See `specs/008-cross-platform-ui/bugfix-plan.md` for detailed rationale.
