### PR TITLE
fix(ci): stabilize nightly self-heal and orchestration

### DIFF
--- a/.github/workflows/deploy-and-heal.yml
+++ b/.github/workflows/deploy-and-heal.yml
@@ -38,6 +38,10 @@ on:
         description: "Image tag to deploy (optional — builds from HEAD if omitted)"
         required: false
         type: string
+      source-issue-number:
+        description: "Issue number to post deploy/self-heal diagnostics to"
+        required: false
+        type: string
   # Trigger self-healing when nightly deploy job fails (item 5)
   workflow_run:
     workflows: ["Nightly Build & Deploy"]
@@ -134,6 +138,7 @@ jobs:
       APP_NAME: ca-acroyoga-web-${{ inputs.environment || 'nightly' }}
       MAX_ITERATIONS: ${{ inputs.max-heal-iterations || 3 }}
       REGISTRY: ${{ secrets.AZURE_CONTAINER_REGISTRY }}
+      SOURCE_ISSUE_NUMBER: ${{ inputs.source-issue-number || '' }}
 
     steps:
       - uses: actions/checkout@v5
@@ -272,6 +277,7 @@ jobs:
           MAX_ITERATIONS: ${{ env.MAX_ITERATIONS }}
           REGISTRY: ${{ env.REGISTRY }}
           BASELINE_REVISION: ${{ steps.baseline.outputs.revision }}
+          SOURCE_ISSUE_NUMBER: ${{ env.SOURCE_ISSUE_NUMBER }}
         with:
           script: |
             const { execSync } = require('child_process');
@@ -280,6 +286,8 @@ jobs:
             const rg = process.env.RESOURCE_GROUP;
             const registry = process.env.REGISTRY;
             const baselineRevision = process.env.BASELINE_REVISION;
+            const sourceIssueNumber = parseInt(process.env.SOURCE_ISSUE_NUMBER || '', 10) || 0;
+            const runIdSuffix = (process.env.GITHUB_RUN_ID || String(Date.now())).slice(-6);
             let imageTag = process.env.IMAGE_TAG;
 
             // Base cooldown: 60s, doubles each iteration (item 8: rate limiting)
@@ -296,7 +304,7 @@ jobs:
             }
 
             // Item 7: Improved PR merge detection — search by issue reference
-            async function waitForPR(issueNumber, timeoutMs = 3600000) {
+            async function waitForPR(issueNumber, timeoutMs = 900000) {
               const deadline = Date.now() + timeoutMs;
               const pollInterval = 60000;
               const createdAfter = new Date(Date.now() - timeoutMs).toISOString().split('T')[0];
@@ -331,6 +339,24 @@ jobs:
                 await new Promise(r => setTimeout(r, pollInterval));
               }
               return null;
+            }
+
+            async function commentSourceIssue(title, lines) {
+              if (!sourceIssueNumber) return;
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: sourceIssueNumber,
+                  body: [
+                    `## ${title}`,
+                    '',
+                    ...lines,
+                  ].join('\n')
+                });
+              } catch (e) {
+                console.log(`Could not comment on source issue #${sourceIssueNumber}: ${e.message}`);
+              }
             }
 
             // Item 4: Automatic rollback helper
@@ -370,7 +396,7 @@ jobs:
               // ── Step 1: Deploy new revision as canary ──
               console.log('Deploying canary revision...');
               const tagSuffix = imageTag.replace(/[^a-z0-9]/gi, '').slice(-6);
-              const revisionSuffix = `h${iter}-${tagSuffix}`;
+              const revisionSuffix = `h${iter}-${tagSuffix}-${runIdSuffix}`;
 
               try {
                 run(`az containerapp update \
@@ -383,6 +409,18 @@ jobs:
                 console.log(`::error title=DEPLOY::Canary deploy failed: ${e.message}`);
                 const infraError = runSafe(`az deployment group list \
                   --resource-group ${rg} --query "[?properties.provisioningState!='Succeeded'] | [0:3]" -o json`);
+                await commentSourceIssue('❌ Self-heal canary deploy failed', [
+                  `- Environment: \`${rg}\``,
+                  `- App: \`${appName}\``,
+                  `- Iteration: ${iter}/${maxIter}`,
+                  `- Image tag: \`${imageTag}\``,
+                  `- Revision suffix: \`${revisionSuffix}\``,
+                  '',
+                  '### Error',
+                  '```',
+                  String(e.message || e).slice(-3000),
+                  '```'
+                ]);
                 core.setOutput('result', 'fail');
                 core.setOutput('error', `Infrastructure deployment failed at iteration ${iter}: ${infraError}`);
                 return;
@@ -446,6 +484,17 @@ jobs:
               // ── Step 3: If all pass → success ──
               if (allPassed) {
                 console.log('\n✅ All smoke tests passed — deployment successful!');
+                await commentSourceIssue('✅ Self-heal deployment succeeded', [
+                  `- Environment: \`${rg}\``,
+                  `- App: \`${appName}\``,
+                  `- Iteration: ${iter}/${maxIter}`,
+                  `- Image tag: \`${imageTag}\``,
+                  '',
+                  '### Smoke Test Results',
+                  '- Readiness (/api/ready): ✅ pass',
+                  '- Health (/api/health): ✅ pass',
+                  '- Home page (/): ✅ pass'
+                ]);
                 core.setOutput('result', 'pass');
                 core.setOutput('iteration', String(iter));
                 return;
@@ -618,6 +667,20 @@ jobs:
                 labels: ['deploy-fix-auto', 'copilot']
               });
 
+              await commentSourceIssue(`🔁 Self-heal iteration ${iter}/${maxIter} failed`, [
+                `- Environment: \`${rg}\``,
+                `- App: \`${appName}\``,
+                `- Image tag: \`${imageTag}\``,
+                `- Error category: \`${errorCategory}\``,
+                `- Summary: ${errorSummary}`,
+                `- Auto-created fix issue: #${fixIssue.number}`,
+                '',
+                '### Smoke Test Results',
+                `- Readiness (/api/ready): ${readinessOk ? '✅ pass' : '❌ fail'}`,
+                `- Health (/api/health): ${healthOk ? '✅ pass' : '❌ fail'}`,
+                `- Home page (/): ${homepageOk ? '✅ pass' : '❌ fail'}`
+              ]);
+
               // Update the issue body with the actual issue number now that we have it
               await github.rest.issues.update({
                 owner: context.repo.owner,
@@ -631,7 +694,7 @@ jobs:
               // ── Step 7: Wait for the agent to merge a fix PR ──
               console.log(`Waiting for Copilot agent to fix issue #${fixIssue.number}...`);
 
-              const fixPR = await waitForPR(fixIssue.number, 3600000); // 1 hour timeout
+              const fixPR = await waitForPR(fixIssue.number, 900000); // 15 minute timeout
 
               if (!fixPR) {
                 console.log(`::warning title=SELF-HEAL::No fix PR merged within timeout for issue #${fixIssue.number}`);
@@ -698,7 +761,7 @@ jobs:
       - name: Report result
         if: always()
         run: |
-          RESULT="${{ steps.heal-loop.outputs.result }}"
+          RESULT="${{ steps.heal-loop.outputs.result || 'fail' }}"
           if [ "$RESULT" = "pass" ]; then
             echo "::notice title=Deploy & Self-Heal::✅ Deployment successful (iteration ${{ steps.heal-loop.outputs.iteration }})"
           else

--- a/.github/workflows/deploy-fix-orchestrate.yml
+++ b/.github/workflows/deploy-fix-orchestrate.yml
@@ -12,19 +12,34 @@ on:
     types: [labeled]
 
 permissions:
+  actions: write
   contents: write
   issues: write
 
 jobs:
   orchestrate-fix:
     if: >
-      github.event.label.name == 'copilot' &&
       contains(github.event.issue.labels.*.name, 'deploy-fix-auto')
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v5
+
+      - name: Ensure copilot label exists on issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const labels = issue.labels.map(l => l.name);
+            if (!labels.includes('copilot')) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['copilot']
+              });
+            }
 
       - name: Create fix branch
         id: branch
@@ -35,11 +50,33 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "${BRANCH}"
 
-          # Use an empty commit instead of marker files to avoid repo accumulation
-          git commit --allow-empty -m "chore: scaffold deploy fix for issue #${ISSUE_NUMBER}"
-          git push origin "${BRANCH}"
+          if git ls-remote --heads origin "${BRANCH}" | grep -q "${BRANCH}"; then
+            echo "Branch ${BRANCH} already exists on origin — reusing"
+          else
+            git checkout -b "${BRANCH}"
+            # Use an empty commit instead of marker files to avoid repo accumulation
+            git commit --allow-empty -m "chore: scaffold deploy fix for issue #${ISSUE_NUMBER}"
+            git push origin "${BRANCH}"
+          fi
+
+      - name: Trigger Deploy & Self-Heal workflow
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'deploy-and-heal.yml',
+              ref: 'main',
+              inputs: {
+                environment: 'nightly',
+                'deploy-infrastructure': 'true',
+                'max-heal-iterations': '3',
+                'source-issue-number': String(issue.number)
+              }
+            });
 
       - name: Update issue with branch info
         uses: actions/github-script@v7
@@ -57,6 +94,7 @@ jobs:
                 '',
                 `- Branch: \`${branch}\``,
                 `- Issue: #${issue.number}`,
+                '- Triggered workflow: `Deploy & Self-Heal`',
                 '',
                 'A Copilot agent will pick up this issue and:',
                 '1. Read the deployment error diagnostics above',
@@ -71,18 +109,10 @@ jobs:
               ].join('\n')
             });
 
-            // Note: The 'copilot' label was already applied when this workflow
-            // triggered (lines 20-22 filter on it). The label re-application below is
-            // intentionally kept as a no-op safety net in case external automation
-            // removes the label during the orchestration window.
-            try {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                labels: ['copilot']
-              });
-            } catch (e) {
-              // Label already exists — expected
-              console.log(`Label already applied: ${e.message}`);
-            }
+            // Keep a no-op re-apply for robustness against external automation.
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: ['copilot']
+            });


### PR DESCRIPTION
## What this fixes\n\nDiagnoses and fixes the current workflow failures:\n\n1. Deploy & Self-Heal failing immediately due to duplicate revision suffix (h1-<sha> already existing).\n2. Deploy & Self-Heal appearing stuck for hours due to 1h PR wait inside retry loop + 2h job timeout.\n3. Deploy-fix orchestration skipping/failing depending on label order and existing branch state.\n\n## Changes\n\n- deploy-and-heal.yml\n  - Add unique run-based suffix to canary revisions to prevent collisions.\n  - Reduce PR merge wait timeout from 60m to 15m to stay within job budget.\n  - Add source-issue diagnostics comments for canary failure, iteration failure, and success.\n  - Add source-issue-number workflow input/env wiring.\n  - Make report step robust with default fail fallback when output is empty.\n\n- deploy-fix-orchestrate.yml\n  - Trigger on presence of deploy-fix-auto label (order-independent).\n  - Ensure copilot label is present automatically.\n  - Make branch creation idempotent (reuse existing branch).\n  - Auto-dispatch Deploy & Self-Heal with issue context (source-issue-number).\n  - Add ctions: write permission for workflow dispatch.\n\n## Validation\n\n- Reviewed failing runs: 24541525442, 24542448712, 24527912018.\n- Confirmed root causes from logs and updated workflows accordingly.\n- YAML diagnostics check returned no errors for changed files.\n