### PR TITLE
fix(docker): bundle @azure/identity into migrate.cjs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,7 @@ RUN npx --yes esbuild apps/web/src/db/migrate.ts \
   --platform=node \
   --format=cjs \
   --outfile=migrate.cjs \
-  --external:pg \
-  --external:@azure/identity
+  --external:pg
 
 # Stage 2: Production runner
 FROM acracroyogai6t2epo2hhajo.azurecr.io/node:22-alpine AS runner


### PR DESCRIPTION
## Root cause

Container revisions were failing with \ERR_MODULE_NOT_FOUND: Cannot find package '@azure/identity'\ on every startup, causing activation failure and the nightly readiness probe to time out after 930s.

The Dockerfile built \migrate.cjs\ with \--external:@azure/identity\, meaning esbuild excluded it from the bundle. But the production stage only copies the Next.js standalone output — \@azure/identity\ is never present there at runtime.

## Fix

Remove \--external:@azure/identity\ so esbuild bundles it directly into \migrate.cjs\. \@azure/identity\ is pure JavaScript with no native addons so bundling is safe. \--external:pg\ is retained as \pg\ has native bindings that cannot be bundled.

Fixes the core nightly failure that has been present for 5+ consecutive days.