### PR TITLE
fix(ci): prevent stale self-heal runs from redeploying old images

### DIFF
--- a/.github/workflows/deploy-and-heal.yml
+++ b/.github/workflows/deploy-and-heal.yml
@@ -50,7 +50,7 @@ on:
 # Prevent overlapping self-heal runs
 concurrency:
   group: deploy-heal-${{ inputs.environment || 'nightly' }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -121,7 +121,7 @@ jobs:
     if: >
       always() && (
         (github.event_name == 'workflow_dispatch' && (needs.build.result == 'success' || needs.build.result == 'skipped')) ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure')
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.head_sha == github.sha)
       )
     environment: ${{ inputs.environment || 'nightly' }}
     permissions:


### PR DESCRIPTION
## Why
Old \workflow_run\ self-heal runs can remain queued/running after newer commits merge to \main\. Those stale runs may redeploy an older \
ightly-sha-*\ image and overwrite a good revision.

## Changes
- Set \cancel-in-progress: true\ for deploy-heal concurrency.
- In \deploy-and-heal\ job gate, only run workflow_run self-heal when:
  - nightly conclusion is failure, and
  - \github.event.workflow_run.head_sha == github.sha\.

This blocks stale trigger replays from older SHAs and keeps healing aligned with current \main\.